### PR TITLE
Belongs to many without pagination.

### DIFF
--- a/app/Http/GraphQL/Queries/CarQuery.php
+++ b/app/Http/GraphQL/Queries/CarQuery.php
@@ -8,6 +8,6 @@ class CarQuery
 {
     public function resolve($root, array $args)
     {
-        return Car::with('options')->get();
+        return Car::get();
     }
 }

--- a/app/Http/GraphQL/Queries/CarQuery.php
+++ b/app/Http/GraphQL/Queries/CarQuery.php
@@ -8,6 +8,6 @@ class CarQuery
 {
     public function resolve($root, array $args)
     {
-        return Car::get();
+        return Car::with('options')->get();
     }
 }

--- a/routes/graphql/schema.graphql
+++ b/routes/graphql/schema.graphql
@@ -1,7 +1,7 @@
 type Car {
   make: String!
   year: Int!
-  extras: [CarOption!]! @hasMany(type: "relay" relation: "options")
+  options: [CarOption!]!
 }
 
 type CarOption {
@@ -10,5 +10,6 @@ type CarOption {
 }
 
 type Query {
-  cars: [Car!]! @field(class: "App\\Http\\GraphQL\\Queries\\CarQuery" method: "resolve")
+  cars: [Car!]!
+    @field(class: "App\\Http\\GraphQL\\Queries\\CarQuery", method: "resolve")
 }

--- a/routes/graphql/schema.graphql
+++ b/routes/graphql/schema.graphql
@@ -1,7 +1,9 @@
 type Car {
   make: String!
   year: Int!
-  options: [CarOption!]!
+
+  extras: [CarOption!]! @hasMany(type: "default", relation: "options")
+  # options: [CarOption!]!
 }
 
 type CarOption {


### PR DESCRIPTION
@chrissm79, you are awesome, migrations and seeds, wow, 🎉

I didn't see the relationship was handle by yourself, your base project got so much power, I'm amazed.

In this commit, its what works for this particular case, pagination here makes no sense, this is what I end up doing, and with something like this:

```graphql
{
  cars {
    make
    year
    options {
      name
      cost
    }
  }
}
```

Im getting the data as I need it

```json
{
  "data": {
    "cars": [
      {
        "make": "Acura",
        "year": 2019,
        "options": [
          {
            "name": "quia",
            "cost": 51.18
          },
          {
            "name": "sint",
            "cost": 164.5
          },
```
